### PR TITLE
feat : [002-USERINFO-API] 유저 정보 API 구현

### DIFF
--- a/api/src/main/kotlin/com/zerobase/api/loan/GenerateKeys.kt
+++ b/api/src/main/kotlin/com/zerobase/api/loan/GenerateKeys.kt
@@ -1,0 +1,9 @@
+package com.zerobase.api.loan
+
+import org.springframework.stereotype.Component
+import java.util.*
+
+@Component
+class GenerateKeys {
+    fun generateUserKey() = UUID.randomUUID().toString().replace("-", "")
+}

--- a/api/src/main/kotlin/com/zerobase/api/loan/encrypt/EncryptComponents.kt
+++ b/api/src/main/kotlin/com/zerobase/api/loan/encrypt/EncryptComponents.kt
@@ -1,0 +1,37 @@
+package com.zerobase.api.loan.encrypt
+
+import org.springframework.stereotype.Component
+import java.util.*
+import javax.crypto.Cipher
+import javax.crypto.spec.IvParameterSpec
+import javax.crypto.spec.SecretKeySpec
+
+@Component
+class EncryptComponents {
+    companion object {
+        private const val secretKey = "12345678901234561234567890123456"
+    }
+
+    private val encoder = Base64.getEncoder()
+    private val decoder = Base64.getDecoder()
+
+    fun encryptString(encryptString: String): String {
+        val encryptedString = cipherPkcs5(Cipher.ENCRYPT_MODE, secretKey).doFinal(encryptString.toByteArray(Charsets.UTF_8))
+
+        return String(encoder.encode(encryptedString))
+    }
+
+    fun decryptString(decryptString: String): String {
+        val byteString = decoder.decode(decryptString.toByteArray(Charsets.UTF_8))
+
+        return String(cipherPkcs5(Cipher.DECRYPT_MODE, secretKey).doFinal(byteString))
+    }
+
+    fun cipherPkcs5(opMode: Int, secretKey: String): Cipher {
+        val c = Cipher.getInstance("AES/CBC/PKCS5Padding")
+        val sk = SecretKeySpec(secretKey.toByteArray(Charsets.UTF_8), "AES")
+        val iv = IvParameterSpec(secretKey.substring(0, 16).toByteArray(Charsets.UTF_8))
+        c.init(opMode, sk, iv)
+        return c
+    }
+}

--- a/api/src/main/kotlin/com/zerobase/api/loan/request/LoanRequestServiceImpl.kt
+++ b/api/src/main/kotlin/com/zerobase/api/loan/request/LoanRequestServiceImpl.kt
@@ -1,29 +1,27 @@
 package com.zerobase.api.loan.request
 
-import com.zerobase.api.loan.GenerateKey
-import com.zerobase.api.loan.encrypt.EncryptComponent
+import com.zerobase.api.loan.GenerateKeys
+import com.zerobase.api.loan.encrypt.EncryptComponents
 import com.zerobase.domain.repository.UserInfoRepository
 import com.zerobase.kafka.enum.KafkaTopic
 import com.zerobase.kafka.producer.LoanRequestSender
-import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.cache.annotation.Cacheable
 import org.springframework.stereotype.Service
 
 @Service
 class LoanRequestServiceImpl(
-    private val generateKey: GenerateKey,
-    private val userInfoRepository: UserInfoRepository,
-    private val encryptComponent: EncryptComponent,
-    private val loanRequestSender: LoanRequestSender
+        private val generateKeys: GenerateKeys,
+        private val userInfoRepository: UserInfoRepository,
+        private val encryptComponents: EncryptComponents,
+        private val loanRequestSender: LoanRequestSender
 ): LoanRequestService {
 
     override fun loanRequestMain(
         loanRequestInputDto: LoanRequestDto.LoanRequestInputDto
     ): LoanRequestDto.LoanRequestResponseDto {
-        val userKey = generateKey.generateUserKey()
+        val userKey = generateKeys.generateUserKey()
 
         loanRequestInputDto.userRegistrationNumber =
-            encryptComponent.encryptString(loanRequestInputDto.userRegistrationNumber)
+            encryptComponents.encryptString(loanRequestInputDto.userRegistrationNumber)
 
         val userInfoDto = loanRequestInputDto.toUserInfoDto(userKey)
 

--- a/api/src/main/kotlin/com/zerobase/api/user/GenerateKey.kt
+++ b/api/src/main/kotlin/com/zerobase/api/user/GenerateKey.kt
@@ -1,4 +1,4 @@
-package com.zerobase.api.loan
+package com.zerobase.api.user
 
 import org.springframework.stereotype.Component
 import java.util.*

--- a/api/src/main/kotlin/com/zerobase/api/user/controller/UserController.kt
+++ b/api/src/main/kotlin/com/zerobase/api/user/controller/UserController.kt
@@ -1,0 +1,35 @@
+package com.zerobase.api.user.controller
+
+import com.zerobase.api.user.model.UserInfoDto
+import com.zerobase.api.user.service.UserInfoServiceImpl
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/fintech/v1/user")
+class UserController(
+        private val userInfoServiceImpl: UserInfoServiceImpl
+) {
+    @PostMapping("/information")
+    fun createUserInfo(
+            @RequestBody userInfoRequestDto: UserInfoDto.UserInfoRequestDto
+    ): ResponseEntity<UserInfoDto.UserInfoResponseDto> {
+        return ResponseEntity.ok(
+                userInfoServiceImpl.createUserInfo(userInfoRequestDto)
+        )
+    }
+
+    @GetMapping("/private-info/{userKey}")
+    fun getUserInfo(
+            @PathVariable userKey: String
+    ): ResponseEntity<UserInfoDto.GetUserInfoResponseDto> {
+        return ResponseEntity.ok(
+            userInfoServiceImpl.getUserInfo(userKey)
+        )
+    }
+}

--- a/api/src/main/kotlin/com/zerobase/api/user/encrypt/EncryptComponent.kt
+++ b/api/src/main/kotlin/com/zerobase/api/user/encrypt/EncryptComponent.kt
@@ -1,4 +1,4 @@
-package com.zerobase.api.loan.encrypt
+package com.zerobase.api.user.encrypt
 
 import org.springframework.stereotype.Component
 import java.util.*

--- a/api/src/main/kotlin/com/zerobase/api/user/model/UserInfoDto.kt
+++ b/api/src/main/kotlin/com/zerobase/api/user/model/UserInfoDto.kt
@@ -1,0 +1,35 @@
+package com.zerobase.api.user.model
+
+import com.zerobase.domain.domain.UserInfo
+
+class UserInfoDto {
+    data class UserInfoRequestDto(
+            val userName: String,
+            val userIncomeAmount: Long,
+            var userRegistrationNumber: String
+    ) {
+        fun toUserInfoDBDto(userKey: String) =
+                UserInfoDBDto(
+                        userKey, userName, userRegistrationNumber, userIncomeAmount
+                )
+    }
+
+    data class UserInfoResponseDto(
+            val userKey: String
+    )
+
+    data class UserInfoDBDto(
+            val userKey: String,
+            val userName: String,
+            val userRegistrationNumber: String,
+            val userIncomeAmount: Long
+    ) {
+        fun toEntity(): UserInfo =
+                UserInfo(userKey, userRegistrationNumber, userName, userIncomeAmount)
+    }
+
+    data class GetUserInfoResponseDto(
+            val userKey: String,
+            val userRegistrationNumber: String
+    )
+}

--- a/api/src/main/kotlin/com/zerobase/api/user/service/UserInfoService.kt
+++ b/api/src/main/kotlin/com/zerobase/api/user/service/UserInfoService.kt
@@ -1,0 +1,16 @@
+package com.zerobase.api.user.service
+
+import com.zerobase.api.user.model.UserInfoDto
+import com.zerobase.domain.domain.UserInfo
+
+interface UserInfoService {
+    fun createUserInfo(
+            userInfoRequestDto: UserInfoDto.UserInfoRequestDto
+    ): UserInfoDto.UserInfoResponseDto
+
+    fun saveUserInfo(
+            userInfoDBDto: UserInfoDto.UserInfoDBDto
+    ): UserInfo
+
+    fun getUserInfo(userKey: String): UserInfoDto.GetUserInfoResponseDto
+}

--- a/api/src/main/kotlin/com/zerobase/api/user/service/UserInfoServiceImpl.kt
+++ b/api/src/main/kotlin/com/zerobase/api/user/service/UserInfoServiceImpl.kt
@@ -1,0 +1,43 @@
+package com.zerobase.api.user.service
+
+import com.zerobase.api.user.GenerateKey
+import com.zerobase.api.user.encrypt.EncryptComponent
+import com.zerobase.api.user.model.UserInfoDto
+import com.zerobase.domain.domain.UserInfo
+import com.zerobase.domain.repository.UserInfoRepository
+import org.springframework.stereotype.Service
+
+@Service
+class UserInfoServiceImpl(
+        private val generateKey: GenerateKey,
+        private val userInfoRepository: UserInfoRepository,
+        private val encryptComponent: EncryptComponent
+): UserInfoService {
+    override fun createUserInfo(
+            userInfoRequestDto: UserInfoDto.UserInfoRequestDto
+    ): UserInfoDto.UserInfoResponseDto {
+        val userKey = generateKey.generateUserKey()
+
+        userInfoRequestDto.userRegistrationNumber =
+                encryptComponent.encryptString(userInfoRequestDto.userRegistrationNumber)
+
+        val userInfoDBDto = userInfoRequestDto.toUserInfoDBDto(userKey)
+
+        saveUserInfo(userInfoDBDto)
+
+        return UserInfoDto.UserInfoResponseDto(userKey)
+    }
+
+    override fun saveUserInfo(userInfoDBDto: UserInfoDto.UserInfoDBDto): UserInfo {
+        return userInfoRepository.save(userInfoDBDto.toEntity())
+    }
+
+    override fun getUserInfo(userKey: String): UserInfoDto.GetUserInfoResponseDto {
+        val userInfo = userInfoRepository.findByUserKey(userKey)
+
+        return UserInfoDto.GetUserInfoResponseDto(
+                userKey = userKey,
+                userRegistrationNumber = encryptComponent.decryptString(userInfo.userRegistrationNumber)
+        )
+    }
+}

--- a/api/src/test/kotlin/com/zerobase/api/loan/request/LoanRequestControllerTest.kt
+++ b/api/src/test/kotlin/com/zerobase/api/loan/request/LoanRequestControllerTest.kt
@@ -2,8 +2,8 @@ package com.zerobase.api.loan.request
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.KotlinModule
-import com.zerobase.api.loan.GenerateKey
-import com.zerobase.api.loan.encrypt.EncryptComponent
+import com.zerobase.api.loan.GenerateKeys
+import com.zerobase.api.loan.encrypt.EncryptComponents
 import com.zerobase.domain.domain.UserInfo
 import com.zerobase.domain.repository.UserInfoRepository
 import com.zerobase.kafka.producer.LoanRequestSender
@@ -26,9 +26,9 @@ internal class LoanRequestControllerTest {
 
     private lateinit var loanRequestController: LoanRequestController
 
-    private lateinit var generateKey: GenerateKey
+    private lateinit var generateKeys: GenerateKeys
 
-    private lateinit var encryptComponent: EncryptComponent
+    private lateinit var encryptComponents: EncryptComponents
 
     private lateinit var loanRequestSender : LoanRequestSender
 
@@ -45,12 +45,12 @@ internal class LoanRequestControllerTest {
 
     @BeforeEach
     fun init() {
-        generateKey = GenerateKey()
+        generateKeys = GenerateKeys()
 
-        encryptComponent = EncryptComponent()
+        encryptComponents = EncryptComponents()
 
         loanRequestServiceImpl = LoanRequestServiceImpl(
-            generateKey, userInfoRepository, encryptComponent, loanRequestSender
+            generateKeys, userInfoRepository, encryptComponents, loanRequestSender
         )
 
         loanRequestController = LoanRequestController(loanRequestServiceImpl)


### PR DESCRIPTION
Changes
___

feat : [002-USERINFO-API] 유저 정보 API 구현
- /fintech/v1/user/information : 유저 정보를 받는 API
EncryptComponent를 통해 유저의 주민등록번호 암호화
GenerateKey를 통해 유저키 생성
- /fintech/v1/user/private-info/{userKey} : 유저 정보를 조회하는 API
EncryptComponent를 통해 유저의 주민등록번호 복호화